### PR TITLE
handle refunds in Stripe payout events

### DIFF
--- a/src/main/java/com/impactupgrade/nucleus/client/SfdcClient.java
+++ b/src/main/java/com/impactupgrade/nucleus/client/SfdcClient.java
@@ -327,6 +327,12 @@ public class SfdcClient extends SFDCPartnerAPIClient {
     return queryList(query);
   }
 
+  public List<SObject> getRefundsInDeposit(String depositId) throws ConnectionException, InterruptedException {
+    String query = "select " + getFieldsList(DONATION_FIELDS, env.getConfig().salesforce.customQueryFields.donation) + " from Opportunity where " + env.getConfig().salesforce.fieldDefinitions.paymentGatewayRefundDepositId + " = '" + depositId + "'";
+    LoggingUtil.verbose(log, query);
+    return queryList(query);
+  }
+
   public Optional<SObject> getNextPledgedDonationByRecurringDonationId(String recurringDonationId) throws ConnectionException, InterruptedException {
     // TODO: Using TOMORROW to account for timezone issues -- we can typically get away with that approach
     // since most RDs are monthly...

--- a/src/main/java/com/impactupgrade/nucleus/controller/StripeController.java
+++ b/src/main/java/com/impactupgrade/nucleus/controller/StripeController.java
@@ -211,7 +211,7 @@ public class StripeController {
 
         List<PaymentGatewayEvent> paymentGatewayEvents = stripePaymentGatewayService.payoutToPaymentGatewayEvents(payout);
         for (PaymentGatewayEvent paymentGatewayEvent : paymentGatewayEvents) {
-          env.donationService().chargeDeposited(paymentGatewayEvent);
+          env.donationService().processDeposit(paymentGatewayEvent);
         }
       }
       case "customer.source.expiring" -> {

--- a/src/main/java/com/impactupgrade/nucleus/environment/EnvironmentConfig.java
+++ b/src/main/java/com/impactupgrade/nucleus/environment/EnvironmentConfig.java
@@ -85,17 +85,24 @@ public class EnvironmentConfig {
   //  Needs careful thought...
   public static class CRMFieldDefinitions {
     public String paymentGatewayName = "";
+
     public String paymentGatewayTransactionId = "";
     public String paymentGatewayCustomerId = "";
     public String paymentGatewaySubscriptionId = "";
+
     public String paymentGatewayRefundId = "";
     public String paymentGatewayRefundDate = "";
+    public String paymentGatewayRefundDepositId = "";
+    public String paymentGatewayRefundDepositDate = "";
+
     public String paymentGatewayDepositId = "";
     public String paymentGatewayDepositDate = "";
     public String paymentGatewayDepositNetAmount = "";
     public String paymentGatewayDepositFee = "";
+
     public String emailOptIn = "";
     public String emailOptOut = "";
+
     public String smsOptIn = "";
     public String smsOptOut = "";
   }

--- a/src/main/java/com/impactupgrade/nucleus/model/PaymentGatewayDeposit.java
+++ b/src/main/java/com/impactupgrade/nucleus/model/PaymentGatewayDeposit.java
@@ -53,7 +53,7 @@ public class PaymentGatewayDeposit {
 
   // TODO: May need to rethink the following, since hierarchies of funds was somewhat of a TER-specific concept.
 
-  public void addTransaction(double gross, double net, double fee, double refund, String parentFund, String fund) {
+  public void addTransaction(double gross, double net, double fee, String parentFund, String fund) {
     if (!ledgers.containsKey(parentFund)) {
       Ledger ledger = new Ledger();
       ledgers.put(parentFund, ledger);
@@ -66,14 +66,12 @@ public class PaymentGatewayDeposit {
     ledgers.get(parentFund).gross += gross;
     ledgers.get(parentFund).net += net;
     ledgers.get(parentFund).fees += fee;
-    ledgers.get(parentFund).refunds += refund;
     ledgers.get(parentFund).subLedgers.get(fund).gross += gross;
     ledgers.get(parentFund).subLedgers.get(fund).net += net;
     ledgers.get(parentFund).subLedgers.get(fund).fees += fee;
-    ledgers.get(parentFund).subLedgers.get(fund).refunds += refund;
   }
 
-  public void addTransaction(double gross, double net, double fee, double refund, String fund) {
+  public void addTransaction(double gross, double net, double fee, String fund) {
     if (Strings.isNullOrEmpty(fund)) {
       fund = "General";
     }
@@ -86,6 +84,32 @@ public class PaymentGatewayDeposit {
     ledgers.get(fund).gross += gross;
     ledgers.get(fund).net += net;
     ledgers.get(fund).fees += fee;
+  }
+
+  public void addRefund(double refund, String parentFund, String fund) {
+    if (!ledgers.containsKey(parentFund)) {
+      Ledger ledger = new Ledger();
+      ledgers.put(parentFund, ledger);
+    }
+    if (!ledgers.get(parentFund).subLedgers.containsKey(fund)) {
+      Ledger ledger = new Ledger();
+      ledgers.get(parentFund).subLedgers.put(fund, ledger);
+    }
+
+    ledgers.get(parentFund).refunds += refund;
+    ledgers.get(parentFund).subLedgers.get(fund).refunds += refund;
+  }
+
+  public void addRefund(double refund, String fund) {
+    if (Strings.isNullOrEmpty(fund)) {
+      fund = "General";
+    }
+
+    if (!ledgers.containsKey(fund)) {
+      Ledger ledger = new Ledger();
+      ledgers.put(fund, ledger);
+    }
+
     ledgers.get(fund).refunds += refund;
   }
 

--- a/src/main/java/com/impactupgrade/nucleus/service/logic/DonationService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/logic/DonationService.java
@@ -147,7 +147,7 @@ public class DonationService {
     }
   }
 
-  public void chargeDeposited(PaymentGatewayEvent paymentGatewayEvent) throws Exception {
+  public void processDeposit(PaymentGatewayEvent paymentGatewayEvent) throws Exception {
     Optional<CrmDonation> donation = crmService.getDonation(paymentGatewayEvent);
 
     if (donation.isEmpty()) {

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/HubSpotCrmService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/HubSpotCrmService.java
@@ -428,6 +428,8 @@ public class HubSpotCrmService implements CrmService {
       return;
     }
 
+    // TODO: update to reflect the same process used in SfdcCrmService? Missing refund processing, etc.
+
     DealProperties deal = new DealProperties();
     setProperty(env.getConfig().hubspot.fieldDefinitions.paymentGatewayDepositId, paymentGatewayEvent.getDepositId(), deal.getOtherProperties());
     setProperty(env.getConfig().hubspot.fieldDefinitions.paymentGatewayDepositDate, paymentGatewayEvent.getDepositDate(), deal.getOtherProperties());


### PR DESCRIPTION
@LandonBaer721 This is a bit of follow-up work to the gross vs. net vs. fees vs. refunds work you did in the deposit report. In order to know for sure what payout date a refund was processed, we need the payout ID tracked separately.

Ex:

Initial donation received on the 15th, deposited on the 17th. On the 21st, it's refunded, and those funds are taken back out of the checking account on the 23rd -- that refund will show up in the Payout event from Stripe on the 23rd. In order to show that refund coming back out in the deposit report for the 23rd, we need to separately track the payout it was actually a part of. At the moment, we'll instead show the refund on the original donation deposit on the **17th**, which wasn't true.

CC @ZFerlise20 