### PR TITLE
14213: SMS Campaign Executor periodically failing

### DIFF
--- a/src/main/java/com/impactupgrade/nucleus/service/logic/SmsCampaignJobExecutor.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/logic/SmsCampaignJobExecutor.java
@@ -352,9 +352,4 @@ public class SmsCampaignJobExecutor implements JobExecutor {
     @JsonProperty("message")
     public String messageBody;
   }
-
-  public static void main(String[] args) {
-    Integer i = null;
-    System.out.println(i + 1);
-  }
 }


### PR DESCRIPTION
JobProgress is created/persisted but not updated with lastMessage field in json payload.
Possible cases:
- nextMessage > jobPayload.sequenceMessages.size() (when next message is '1' and 'sequence messages' is empty)
- exception is thrown from SmsCampaignJobExecutor class between lines 170 and 186 (getDefaultLanguage, getMessage, messagingService.sendMessage)