### PR TITLE
MC Sync: replace tagsToPreserve with controlledTags

### DIFF
--- a/src/main/java/com/impactupgrade/nucleus/client/MailchimpClient.java
+++ b/src/main/java/com/impactupgrade/nucleus/client/MailchimpClient.java
@@ -97,7 +97,6 @@ public class MailchimpClient {
           upsertMemberMethod.mapping.putAll(contact.mapping);
           upsertMemberMethod.merge_fields.mapping.putAll(contact.merge_fields.mapping);
           upsertMemberMethod.interests.mapping.putAll(contact.interests.mapping);
-          upsertMemberMethod.tags = contact.tags;
           return upsertMemberMethod;
         })
         .collect(Collectors.toList());

--- a/src/main/java/com/impactupgrade/nucleus/environment/EnvironmentConfig.java
+++ b/src/main/java/com/impactupgrade/nucleus/environment/EnvironmentConfig.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -304,7 +305,12 @@ public class EnvironmentConfig implements Serializable {
   }
   public static class CommunicationPlatform extends Platform {
     public List<CommunicationList> lists = new ArrayList<>();
-    public Set<String> tagsToPreserve = new HashSet<>();
+    // The set of tags that this instance of Nucleus controls, which defines which tags we're allowed to remove from
+    // the contact once the conditions are no longer met. This ensures any of the client's manually-defined tags
+    // are preserved.
+    // TODO: Until we introduce something like PIKL, there's not a great way to define this in environment-default.json
+    //  since it needs to happen within the list of individual instances.
+    public Set<String> controlledTags = new HashSet<>(Arrays.asList("donor", "owner_", "campaign_", "account_type_"));
     // Transactional email (donation receipts, notifications, etc.) need one of the email platforms to be
     // designated as the conduit!
     public boolean transactionalSender = false;

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/AbstractCommunicationService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/AbstractCommunicationService.java
@@ -133,6 +133,7 @@ public abstract class AbstractCommunicationService implements CommunicationServi
   // Separate method, allowing orgs to add in (or completely override) the defaults.
   // NOTE: Only use alphanumeric and _ chars! Some providers, like SendGrid, are using custom fields for
   //  tags and have limitations on field names.
+  // IMPORTANT: At the moment, any new tag added here must be added to EnvironmentConfig.CommunicationPlatform.controlledTags!
   protected Set<String> buildContactTags(CrmContact crmContact, List<String> contactCampaignNames,
       EnvironmentConfig.CommunicationPlatform communicationPlatform) throws Exception {
     Set<String> tags = new HashSet<>();
@@ -144,14 +145,6 @@ public abstract class AbstractCommunicationService implements CommunicationServi
     if (crmContact.lastDonationDate != null) {
       tags.add("donor");
     }
-
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // DEMOGRAPHIC INFO
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    // TODO: Would be great to have age, but the field (or "birthdate") tends to be custom within SFDC.
-//      char contactAgeGroup = Integer.toString(primaryCrmService.getAge(contact)).charAt(0);
-//      addTagToContact(listId, contact, "Age: " + contactAgeGroup + "0 - " + contactAgeGroup + "9");
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // INTERNAL INFO


### PR DESCRIPTION
For MC sync, flip the direction of tag preservation in env.json. Instead of maintaining a list of tags to preserve, define the list of tags we actually control.

https://app.shortcut.com/impactupgrade/story/16583/replace-env-json-s-tagstopreserve-with-controlledtags