### PR TITLE
refactors to allow email sync to be broken up into batches

### DIFF
--- a/src/main/java/com/impactupgrade/nucleus/client/MailchimpClient.java
+++ b/src/main/java/com/impactupgrade/nucleus/client/MailchimpClient.java
@@ -67,7 +67,7 @@ public class MailchimpClient {
   public static final String TAG_INACTIVE = "inactive";
 
   // 2 hours
-  protected static Integer BATCH_STATUS_RETRY_WAIT_IN_SECONDS = 300;
+  protected static Integer BATCH_STATUS_RETRY_WAIT_IN_SECONDS = 60;
   protected static Integer BATCH_STATUS_MAX_RETRIES = 24;
 
   protected final com.ecwid.maleorang.MailchimpClient client;

--- a/src/main/java/com/impactupgrade/nucleus/controller/PaypalController.java
+++ b/src/main/java/com/impactupgrade/nucleus/controller/PaypalController.java
@@ -87,7 +87,8 @@ public class PaypalController {
     APIContext apiContext = new APIContext(
         env.getConfig().paypal.clientId, 
         env.getConfig().paypal.clientSecret, 
-        env.getConfig().paypal.mode);
+        env.getConfig().paypal.mode
+    );
     apiContext.addConfiguration(Constants.PAYPAL_WEBHOOK_ID, env.getConfig().paypal.webhookId);
 
     boolean validEvent = Event.validateReceivedEvent(apiContext, getHeadersInfo(request), requestBody);

--- a/src/main/java/com/impactupgrade/nucleus/controller/SfdcController.java
+++ b/src/main/java/com/impactupgrade/nucleus/controller/SfdcController.java
@@ -261,7 +261,7 @@ public class SfdcController {
             env.logJobInfo("processing row {}: {}", counter, email);
 
             if (!Strings.isNullOrEmpty(email)) {
-              Optional<SObject> contact = env.sfdcClient().searchContacts(ContactSearch.byEmail(email)).getSingleResult();
+              Optional<SObject> contact = env.sfdcClient().searchContacts(ContactSearch.byEmail(email)).stream().findFirst();
               if (contact.isPresent()) {
                 // SF expects date in yyyy-MM-dd'T'HH:mm:ss.SSS'Z, but iWave gives yyyy-MM-dd HH:mm
                 Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm").parse(csvRecord.get("Date Scored"));

--- a/src/main/java/com/impactupgrade/nucleus/model/CrmRecord.java
+++ b/src/main/java/com/impactupgrade/nucleus/model/CrmRecord.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class CrmRecord implements Serializable {
+public abstract class CrmRecord implements Serializable {
 
   public String id;
 

--- a/src/main/java/com/impactupgrade/nucleus/model/PagedResults.java
+++ b/src/main/java/com/impactupgrade/nucleus/model/PagedResults.java
@@ -10,57 +10,72 @@ import java.util.List;
 import java.util.Optional;
 
 public class PagedResults<T> {
-  private final List<T> results;
-  private final Integer pageSize;
-  // Could be a numeric offset or string cursor -- each usage must know which to expect
-  private final String nextPageToken;
+  private final List<ResultSet<T>> resultSets = new ArrayList<>();
 
-  public PagedResults(List<T> results, Integer pageSize, String nextPageToken) {
-    this.results = results;
-    this.pageSize = pageSize;
-    this.nextPageToken = nextPageToken;
+  public PagedResults() {}
+
+  public PagedResults(ResultSet<T> resultSet) {
+    resultSets.add(resultSet);
   }
 
-  public PagedResults() {
-    results = new ArrayList<>();
-    pageSize = 0;
-    nextPageToken = null;
+  public void addResultSet(ResultSet<T> resultSet) {
+    resultSets.add(resultSet);
   }
 
-  public List<T> getResults() {
-    return results;
+  public List<ResultSet<T>> getResultSets() {
+    return resultSets;
   }
 
   public Optional<T> getSingleResult() {
-    if (results.isEmpty()) {
-      return Optional.empty();
+    return resultSets.stream().flatMap(rs -> rs.getRecords().stream()).findFirst();
+  }
+
+  public static class ResultSet<T> {
+    private final List<T> records;
+    // Could be a numeric offset or string cursor -- each usage must know which to expect
+    private final String nextPageToken;
+
+    public ResultSet(List<T> records, String nextPageToken) {
+      this.records = records;
+      this.nextPageToken = nextPageToken;
     }
-    return Optional.of(results.get(0));
+
+    public ResultSet() {
+      records = new ArrayList<>();
+      nextPageToken = null;
+    }
+
+    public List<T> getRecords() {
+      return records;
+    }
+
+    public Optional<T> getSingleResult() {
+      if (records.isEmpty()) {
+        return Optional.empty();
+      }
+      return Optional.of(records.get(0));
+    }
+
+    public String getNextPageToken() {
+      return nextPageToken;
+    }
+
+    public static <T> ResultSet<T> resultSetFromCurrentOffset(List<T> results, String nextPageToken) {
+      return new ResultSet<>(results, nextPageToken);
+    }
   }
 
-  public Integer getPageSize() {
-    return pageSize;
-  }
-
-  public boolean hasMorePages() {
-    return results.size() == pageSize;
-  }
-
-  public String getNextPageToken() {
-    return nextPageToken;
-  }
-
-  public static <T> PagedResults<T> getPagedResultsFromCurrentOffset(T result, AbstractSearch currentSearch) {
+  public static <T> PagedResults<T> pagedResultsFromCurrentOffset(T result, AbstractSearch currentSearch) {
     List<T> results = result == null ? Collections.emptyList() : List.of(result);
-    return getPagedResultsFromCurrentOffset(results, currentSearch);
+    return pagedResultsFromCurrentOffset(results, currentSearch);
   }
 
-  public static <T> PagedResults<T> getPagedResultsFromCurrentOffset(Optional<T> result, AbstractSearch currentSearch) {
+  public static <T> PagedResults<T> pagedResultsFromCurrentOffset(Optional<T> result, AbstractSearch currentSearch) {
     List<T> results = result.stream().toList();
-    return getPagedResultsFromCurrentOffset(results, currentSearch);
+    return pagedResultsFromCurrentOffset(results, currentSearch);
   }
 
-  public static <T> PagedResults<T> getPagedResultsFromCurrentOffset(List<T> results, AbstractSearch currentSearch) {
+  public static <T> PagedResults<T> pagedResultsFromCurrentOffset(List<T> results, AbstractSearch currentSearch) {
     String nextPageToken = null;
     if (currentSearch.pageSize != null) {
       Integer currentOffset = currentSearch.getPageOffset();
@@ -71,6 +86,16 @@ public class PagedResults<T> {
       }
     }
 
-    return new PagedResults<>(results, currentSearch.pageSize, nextPageToken);
+    ResultSet<T> resultSet = new ResultSet<>(results, nextPageToken);
+    PagedResults<T> pagedResults = new PagedResults<>();
+    pagedResults.addResultSet(resultSet);
+    return pagedResults;
+  }
+
+  public static <T> PagedResults<T> unpagedResults(List<T> results) {
+    ResultSet<T> resultSet = new ResultSet<>(results, null);
+    PagedResults<T> pagedResults = new PagedResults<>();
+    pagedResults.addResultSet(resultSet);
+    return pagedResults;
   }
 }

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/AbstractCommunicationService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/AbstractCommunicationService.java
@@ -17,11 +17,9 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public abstract class AbstractCommunicationService implements CommunicationService {
@@ -43,18 +41,6 @@ public abstract class AbstractCommunicationService implements CommunicationServi
       return Collections.emptyMap();
     }
     return env.primaryCrmService().getContactCampaignsByContactIds(crmContactIds, communicationList);
-  }
-
-  protected List<CrmContact> getEmailContacts(Calendar lastSync, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    List<CrmContact> crmContacts = env.primaryCrmService().getEmailContacts(lastSync, communicationList);
-
-    Map<String, CrmContact> uniqueContacts = crmContacts.stream().collect(Collectors.toMap(
-        so -> so.email.toLowerCase(Locale.ROOT),
-        Function.identity(),
-        // IMPORTANT: FIFO. If contacts share an email address, the oldest record is typically the truth.
-        (so1, so2) -> so1
-    ));
-    return new ArrayList<>(uniqueContacts.values());
   }
 
   protected List<CustomField> buildContactCustomFields(CrmContact crmContact,

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/BareCrmService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/BareCrmService.java
@@ -65,7 +65,7 @@ public class BareCrmService implements CrmService {
 
   @Override
   public PagedResults<CrmContact> searchContacts(ContactSearch contactSearch) throws Exception {
-    return new PagedResults<>(Collections.emptyList(), 0, "");
+    return new PagedResults<>();
   }
 
   @Override
@@ -208,18 +208,18 @@ public class BareCrmService implements CrmService {
   }
 
   @Override
-  public List<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    return Collections.emptyList();
+  public PagedResults<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
-  public List<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    return Collections.emptyList();
+  public PagedResults<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
-  public List<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    return Collections.emptyList();
+  public PagedResults<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
@@ -261,6 +261,16 @@ public class BareCrmService implements CrmService {
   @Override
   public Optional<CrmUser> getUserByEmail(String email) throws Exception {
     return Optional.empty();
+  }
+
+  @Override
+  public PagedResults.ResultSet<CrmContact> queryMoreContacts(String queryLocator) throws Exception {
+    return null;
+  }
+
+  @Override
+  public PagedResults.ResultSet<CrmAccount> queryMoreAccounts(String queryLocator) throws Exception {
+    return null;
   }
 
   @Override

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/ConstantContactCommunicationService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/ConstantContactCommunicationService.java
@@ -9,11 +9,13 @@ import com.impactupgrade.nucleus.client.ConstantContactClient;
 import com.impactupgrade.nucleus.environment.Environment;
 import com.impactupgrade.nucleus.environment.EnvironmentConfig;
 import com.impactupgrade.nucleus.model.CrmContact;
+import com.impactupgrade.nucleus.model.PagedResults;
 
 import java.util.Calendar;
-import java.util.List;
 import java.util.Optional;
 
+// TODO: NEEDS FULLY UPDATED WITH EVERYTHING NEW IN THE MAILCHIMP SERVICE! Likely implies genericizing some of the MC
+//  logic and pulling it upstream to AbstractCommunicationService.
 public class ConstantContactCommunicationService extends AbstractCommunicationService {
 
   @Override
@@ -32,10 +34,10 @@ public class ConstantContactCommunicationService extends AbstractCommunicationSe
       ConstantContactClient constantContactClient = new ConstantContactClient(communicationPlatform, env);
 
       for (EnvironmentConfig.CommunicationList communicationList : communicationPlatform.lists) {
-        List<CrmContact> crmContacts = env.primaryCrmService().getSmsContacts(lastSync, communicationList);
-        for (CrmContact crmContact : crmContacts) {
-          if (!Strings.isNullOrEmpty(crmContact.phoneNumberForSMS())) {
-            env.logJobInfo("upserting contact {} {} on list {}", crmContact.id, crmContact.phoneNumberForSMS(), communicationList.id);
+        PagedResults<CrmContact> pagedResults = env.primaryCrmService().getEmailContacts(lastSync, communicationList);
+        for (PagedResults.ResultSet<CrmContact> resultSet : pagedResults.getResultSets()) {
+          for (CrmContact crmContact : resultSet.getRecords()) {
+            env.logJobInfo("upserting contact {} {} on list {}", crmContact.id, crmContact.email, communicationList.id);
             constantContactClient.upsertContact(crmContact, communicationList.id);
           }
         }

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/DonorWranglerCrmService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/DonorWranglerCrmService.java
@@ -76,12 +76,12 @@ public class DonorWranglerCrmService implements BasicCrmService {
       Optional<CrmContact> crmContact = toCrmContact(
           dwClient.getContactByEmail(contactSearch.email)
       );
-      return PagedResults.getPagedResultsFromCurrentOffset(crmContact, contactSearch);
+      return PagedResults.pagedResultsFromCurrentOffset(crmContact, contactSearch);
     } else if (!Strings.isNullOrEmpty(contactSearch.phone)) {
       Optional<CrmContact> crmContact = toCrmContact(
           dwClient.contactSearch("phone", contactSearch.phone)
       );
-      return PagedResults.getPagedResultsFromCurrentOffset(crmContact, contactSearch);
+      return PagedResults.pagedResultsFromCurrentOffset(crmContact, contactSearch);
     } else {
       return new PagedResults<>();
     }
@@ -129,6 +129,16 @@ public class DonorWranglerCrmService implements BasicCrmService {
   }
 
   @Override
+  public PagedResults.ResultSet<CrmContact> queryMoreContacts(String queryLocator) throws Exception {
+    return null;
+  }
+
+  @Override
+  public PagedResults.ResultSet<CrmAccount> queryMoreAccounts(String queryLocator) throws Exception {
+    return null;
+  }
+
+  @Override
   public Map<String, String> getContactLists(CrmContactListType listType) throws Exception {
     return Collections.emptyMap();
   }
@@ -139,20 +149,18 @@ public class DonorWranglerCrmService implements BasicCrmService {
   }
 
   @Override
-  public List<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    // TODO: lastUpdate field now available
-    return Collections.emptyList();
+  public PagedResults<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
-  public List<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    return Collections.emptyList();
+  public PagedResults<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
-  public List<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    // TODO: lastUpdate field now available
-    return Collections.emptyList();
+  public PagedResults<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/DynamicsCrmService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/DynamicsCrmService.java
@@ -68,10 +68,10 @@ public class DynamicsCrmService implements BasicCrmService {
     DynamicsCrmClient.Contact contact;
     if (!Strings.isNullOrEmpty(contactSearch.email)) {
       contact = dynamicsCrmClient.getContactByEmail(contactSearch.email);
-      return PagedResults.getPagedResultsFromCurrentOffset(List.of(toCrmContact(contact)), contactSearch);
+      return PagedResults.pagedResultsFromCurrentOffset(List.of(toCrmContact(contact)), contactSearch);
     } else if (!Strings.isNullOrEmpty(contactSearch.phone)) {
       contact = dynamicsCrmClient.getContactByPhoneNumber(contactSearch.phone);
-      return PagedResults.getPagedResultsFromCurrentOffset(List.of(toCrmContact(contact)), contactSearch);
+      return PagedResults.pagedResultsFromCurrentOffset(List.of(toCrmContact(contact)), contactSearch);
     } else {
       return new PagedResults<>();
     }
@@ -162,22 +162,32 @@ public class DynamicsCrmService implements BasicCrmService {
   }
 
   @Override
-  public List<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    return Collections.emptyList();
+  public PagedResults<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
-  public List<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    return Collections.emptyList();
+  public PagedResults<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
-  public List<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    return null;
+  public PagedResults<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
   public List<CrmUser> getUsers() throws Exception {
+    return null;
+  }
+
+  @Override
+  public PagedResults.ResultSet<CrmContact> queryMoreContacts(String queryLocator) throws Exception {
+    return null;
+  }
+
+  @Override
+  public PagedResults.ResultSet<CrmAccount> queryMoreAccounts(String queryLocator) throws Exception {
     return null;
   }
 

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/GoogleSheetCrmService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/GoogleSheetCrmService.java
@@ -112,6 +112,16 @@ public class GoogleSheetCrmService implements BasicCrmService {
     }
 
     @Override
+    public PagedResults.ResultSet<CrmContact> queryMoreContacts(String queryLocator) throws Exception {
+        return null;
+    }
+
+    @Override
+    public PagedResults.ResultSet<CrmAccount> queryMoreAccounts(String queryLocator) throws Exception {
+        return null;
+    }
+
+    @Override
     public Map<String, String> getContactLists(CrmContactListType listType) throws Exception {
         return Collections.emptyMap();
     }
@@ -122,18 +132,18 @@ public class GoogleSheetCrmService implements BasicCrmService {
     }
 
     @Override
-    public List<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-        return Collections.emptyList();
+    public PagedResults<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+        return new PagedResults<>();
     }
 
     @Override
-    public List<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-        return Collections.emptyList();
+    public PagedResults<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+        return new PagedResults<>();
     }
 
     @Override
-    public List<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-        return null;
+    public PagedResults<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+        return new PagedResults<>();
     }
 
     @Override

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/HubSpotCrmService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/HubSpotCrmService.java
@@ -163,10 +163,10 @@ public class HubSpotCrmService implements CrmService {
 
     if (!Strings.isNullOrEmpty(contactSearch.email)) {
       List<CrmContact> contacts = toCrmContact(hsClient.contact().searchByEmail(contactSearch.email, contactFields).getResults());
-      return PagedResults.getPagedResultsFromCurrentOffset(contacts, contactSearch);
+      return PagedResults.pagedResultsFromCurrentOffset(contacts, contactSearch);
     } else if (!Strings.isNullOrEmpty(contactSearch.phone)) {
       List<CrmContact> contacts =  toCrmContact(hsClient.contact().searchByPhone(contactSearch.phone, contactFields).getResults());
-      return PagedResults.getPagedResultsFromCurrentOffset(contacts, contactSearch);
+      return PagedResults.pagedResultsFromCurrentOffset(contacts, contactSearch);
     } else {
       return new PagedResults<>();
     }
@@ -226,6 +226,16 @@ public class HubSpotCrmService implements CrmService {
   public Optional<CrmUser> getUserByEmail(String id) throws Exception {
     // TODO: will need to add User support to HS lib, if even possible
     return Optional.empty();
+  }
+
+  @Override
+  public PagedResults.ResultSet<CrmContact> queryMoreContacts(String queryLocator) throws Exception {
+    return null;
+  }
+
+  @Override
+  public PagedResults.ResultSet<CrmAccount> queryMoreAccounts(String queryLocator) throws Exception {
+    return null;
   }
 
   @Override
@@ -986,7 +996,7 @@ public class HubSpotCrmService implements CrmService {
   }
 
   @Override
-  public List<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+  public PagedResults<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
     List<Filter> filters = new ArrayList<>();
     filters.add(new Filter("email", "HAS_PROPERTY", null));
     if (updatedSince != null) {
@@ -1004,17 +1014,19 @@ public class HubSpotCrmService implements CrmService {
     }
 
     List<FilterGroup> filterGroups = List.of(new FilterGroup(filters));
+    // TODO: We could introduce true pagination in the future, but for now, this isn't as heavy of a lift as SFDC is.
     List<Contact> results = hsClient.contact().searchAutoPaging(filterGroups, contactFields);
-    return results.stream().map(this::toCrmContact).collect(Collectors.toList());
+    List<CrmContact> crmContacts = results.stream().map(this::toCrmContact).collect(Collectors.toList());
+    return PagedResults.unpagedResults(crmContacts);
   }
 
   @Override
-  public List<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-    return Collections.emptyList();
+  public PagedResults<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+    return new PagedResults<>();
   }
 
   @Override
-  public List<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+  public PagedResults<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
     List<Filter> filters1 = new ArrayList<>();
     List<Filter> filters2 = new ArrayList<>();
     filters1.add(new Filter("phone", "HAS_PROPERTY", null));
@@ -1036,8 +1048,10 @@ public class HubSpotCrmService implements CrmService {
     }
 
     List<FilterGroup> filterGroups = List.of(new FilterGroup(filters1), new FilterGroup(filters2));
+    // TODO: We could introduce true pagination in the future, but for now, this isn't as heavy of a lift as SFDC is.
     List<Contact> results = hsClient.contact().searchAutoPaging(filterGroups, contactFields);
-    return results.stream().map(this::toCrmContact).collect(Collectors.toList());
+    List<CrmContact> crmContacts = results.stream().map(this::toCrmContact).collect(Collectors.toList());
+    return PagedResults.unpagedResults(crmContacts);
   }
 
   @Override

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/SendGridCommunicationService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/SendGridCommunicationService.java
@@ -56,7 +56,8 @@ public class SendGridCommunicationService extends AbstractCommunicationService {
 
       for (EnvironmentConfig.CommunicationList communicationList : communicationPlatform.lists) {
         // TODO: SG has a max of 30k per call, so we may need to break this down for some customers.
-        List<CrmContact> crmContacts = env.primaryCrmService().getEmailContacts(lastSync, communicationList);
+        List<CrmContact> crmContacts = env.primaryCrmService().getEmailContacts(lastSync, communicationList)
+            .getResultSets().stream().flatMap(rs -> rs.getRecords().stream()).toList();
         Map<String, List<String>> contactCampaignNames = getContactCampaignNames(crmContacts, communicationList);
 
         env.logJobInfo("upserting {} contacts to list {}", crmContacts.size(), communicationList.id);

--- a/src/main/java/com/impactupgrade/nucleus/service/segment/SharePointCrmService.java
+++ b/src/main/java/com/impactupgrade/nucleus/service/segment/SharePointCrmService.java
@@ -265,7 +265,8 @@ public class SharePointCrmService implements CrmService {
             contactStream = contactStream.limit(contactSearch.pageSize);
         }
         List<CrmContact> results = contactStream.collect(Collectors.toList());
-        return new PagedResults<>(results, contactSearch.pageSize, contactSearch.pageToken);
+        PagedResults.ResultSet<CrmContact> resultSet = new PagedResults.ResultSet<>(results, contactSearch.pageToken);
+        return new PagedResults<>(resultSet);
     }
 
     @Override
@@ -404,18 +405,18 @@ public class SharePointCrmService implements CrmService {
     }
 
     @Override
-    public List<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-        return Collections.emptyList();
+    public PagedResults<CrmContact> getEmailContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+        return new PagedResults<>();
     }
 
     @Override
-    public List<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-        return Collections.emptyList();
+    public PagedResults<CrmAccount> getEmailAccounts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+        return new PagedResults<>();
     }
 
     @Override
-    public List<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
-        return Collections.emptyList();
+    public PagedResults<CrmContact> getSmsContacts(Calendar updatedSince, EnvironmentConfig.CommunicationList communicationList) throws Exception {
+        return new PagedResults<>();
     }
 
     @Override
@@ -456,6 +457,16 @@ public class SharePointCrmService implements CrmService {
     @Override
     public Optional<CrmUser> getUserByEmail(String email) throws Exception {
         return Optional.empty();
+    }
+
+    @Override
+    public PagedResults.ResultSet<CrmContact> queryMoreContacts(String queryLocator) throws Exception {
+        return null;
+    }
+
+    @Override
+    public PagedResults.ResultSet<CrmAccount> queryMoreAccounts(String queryLocator) throws Exception {
+        return null;
     }
 
     @Override

--- a/src/test/java/com/impactupgrade/nucleus/it/AbstractIT.java
+++ b/src/test/java/com/impactupgrade/nucleus/it/AbstractIT.java
@@ -211,7 +211,8 @@ public abstract class AbstractIT extends JerseyTest {
     CrmService crmService = env.crmService("virtuous");
     VirtuousClient virtuousClient = env.virtuousClient();
 
-    List<CrmContact> existingContacts = crmService.searchContacts(ContactSearch.byKeywords("Tester")).getResults();
+    List<CrmContact> existingContacts = crmService.searchContacts(ContactSearch.byKeywords("Tester"))
+        .getResultSets().stream().flatMap(rs -> rs.getRecords().stream()).toList();
     for (CrmContact existingContact : existingContacts) {
       VirtuousClient.Gifts gifts = virtuousClient.getGiftsByContact(Integer.parseInt(existingContact.id));
       for (VirtuousClient.Gift gift : gifts.list) {
@@ -222,7 +223,8 @@ public abstract class AbstractIT extends JerseyTest {
     }
 
     // ensure we're actually clean
-    assertEquals(0, crmService.searchContacts(ContactSearch.byKeywords("Tester")).getResults().size());
+    assertEquals(0, crmService.searchContacts(ContactSearch.byKeywords("Tester")).getResultSets()
+        .stream().flatMap(rs -> rs.getRecords().stream()).toList().size());
   }
 
   protected void postToBulkImport(List<Object> values) throws Exception {

--- a/src/test/java/com/impactupgrade/nucleus/it/CustomDonationsToSfdcIT.java
+++ b/src/test/java/com/impactupgrade/nucleus/it/CustomDonationsToSfdcIT.java
@@ -71,7 +71,7 @@ public class CustomDonationsToSfdcIT extends AbstractIT {
     SfdcClient sfdcClient = env.sfdcClient();
 
     // verify ContactService -> SfdcCrmService
-    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(randomEmail)).getSingleResult();
+    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(randomEmail)).stream().findFirst();
     assertTrue(contactO.isPresent());
     SObject contact = contactO.get();
     String accountId = contact.getField("AccountId").toString();

--- a/src/test/java/com/impactupgrade/nucleus/it/StripeToSfdcIT.java
+++ b/src/test/java/com/impactupgrade/nucleus/it/StripeToSfdcIT.java
@@ -52,7 +52,7 @@ public class StripeToSfdcIT extends AbstractIT {
     SfdcClient sfdcClient = env.sfdcClient();
 
     // verify ContactService -> SfdcCrmService
-    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).getSingleResult();
+    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).stream().findFirst();
     assertTrue(contactO.isPresent());
     SObject contact = contactO.get();
     String accountId = contact.getField("AccountId").toString();
@@ -130,7 +130,7 @@ public class StripeToSfdcIT extends AbstractIT {
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     // verify ContactService -> SfdcCrmService
-    List<SObject> contacts = sfdcClient.searchContacts(ContactSearch.byName(firstName, lastName)).getResults();
+    List<SObject> contacts = sfdcClient.searchContacts(ContactSearch.byName(firstName, lastName));
     // main test -- this would be 2 if the by-name match didn't work
     assertEquals(1, contacts.size());
     SObject contact = contacts.get(0);
@@ -192,7 +192,7 @@ public class StripeToSfdcIT extends AbstractIT {
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     // verify ContactService -> SfdcCrmService
-    List<SObject> contacts = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).getResults();
+    List<SObject> contacts = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail()));
     // this would be 2 if the by-email match didn't work
     assertEquals(1, contacts.size());
     SObject contact = contacts.get(0);
@@ -226,7 +226,7 @@ public class StripeToSfdcIT extends AbstractIT {
 
     SfdcClient sfdcClient = env.sfdcClient();
 
-    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).getSingleResult();
+    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).stream().findFirst();
     assertTrue(contactO.isPresent());
     SObject contact = contactO.get();
     String accountId = contact.getField("AccountId").toString();
@@ -287,7 +287,7 @@ public class StripeToSfdcIT extends AbstractIT {
 
     SfdcClient sfdcClient = env.sfdcClient();
 
-    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).getSingleResult();
+    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).stream().findFirst();
     assertTrue(contactO.isPresent());
     SObject contact = contactO.get();
     String accountId = contact.getField("AccountId").toString();
@@ -334,7 +334,7 @@ public class StripeToSfdcIT extends AbstractIT {
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     // verify ContactService -> SfdcCrmService
-    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).getSingleResult();
+    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).stream().findFirst();
     assertTrue(contactO.isPresent());
     SObject contact = contactO.get();
     String accountId = contact.getField("AccountId").toString();
@@ -402,7 +402,7 @@ public class StripeToSfdcIT extends AbstractIT {
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     // verify ContactService -> SfdcCrmService
-    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).getSingleResult();
+    Optional<SObject> contactO = sfdcClient.searchContacts(ContactSearch.byEmail(customer.getEmail())).stream().findFirst();
     assertTrue(contactO.isPresent());
     SObject contact = contactO.get();
     String accountId = contact.getField("AccountId").toString();


### PR DESCRIPTION
Refactoring multiple layers to allow the MC sync to process contacts in batches, as opposed to loading all contacts into memory in one shot. To review, start with MailchimpCommunicationService, the new methods in CrmService, SfdcCrmService as the main impl, PagedResults, and SfdcClient. The rest of the updates primarily tweak existing code to match the new paradigms, while MC+SFDC is the only true implementation leveraging everything.

IMPORTANT: Before merging this, review and merge https://github.com/impactupgrade/nucleus-engine/pull/220 first as a regression test.