### PR TITLE
HibernateDao constructor to allow passing sessionFactory explicitly

### DIFF
--- a/src/main/java/com/impactupgrade/nucleus/dao/HibernateDao.java
+++ b/src/main/java/com/impactupgrade/nucleus/dao/HibernateDao.java
@@ -30,6 +30,11 @@ public class HibernateDao<I extends Serializable, E> {
     this.sessionFactory = HibernateUtil.getSessionFactory();
   }
 
+  public HibernateDao(Class<E> clazz, SessionFactory sessionFactory) {
+    this.clazz = clazz;
+    this.sessionFactory = sessionFactory;
+  }
+
   public E insert(E entity) {
     final Session session = openSession();
     Transaction transaction = session.beginTransaction();


### PR DESCRIPTION
Expands the `HibernateDao()` constructor to allow a specific `SessionFactory` instance to be passed and set rather than relying on `HibernatUtil` to set it.