### PR TITLE
WIP: save_default_payment_method=on_subscription in Stripe's defaultSubscriptionBuilder

### DIFF
--- a/src/main/java/com/impactupgrade/nucleus/client/StripeClient.java
+++ b/src/main/java/com/impactupgrade/nucleus/client/StripeClient.java
@@ -631,6 +631,13 @@ public class StripeClient {
 
   public SubscriptionCreateParams.Builder defaultSubscriptionBuilder(Customer customer, PaymentSource source,
      SubscriptionCreateParams.PaymentBehavior behavior, Integer autoCancelMonths) {
+    SubscriptionCreateParams.PaymentSettings paymentSettings =
+        SubscriptionCreateParams.PaymentSettings.builder()
+            // not in the older SDK
+//            .setSaveDefaultPaymentMethod(SaveDefaultPaymentMethod.ON_SUBSCRIPTION)
+            .putExtraParam("save_default_payment_method", "on_subscription")
+            .build();
+
     SubscriptionCreateParams.Builder subscriptionCreateParamsBuilder = SubscriptionCreateParams.builder();
     subscriptionCreateParamsBuilder.setCustomer(customer.getId());
 
@@ -651,6 +658,9 @@ public class StripeClient {
       // incomplete invoices, which doesn't give immediate donor feedback
       subscriptionCreateParamsBuilder.setPaymentBehavior(SubscriptionCreateParams.PaymentBehavior.ERROR_IF_INCOMPLETE);
     }
+
+    subscriptionCreateParamsBuilder.setPaymentSettings(paymentSettings);
+
     if (autoCancelMonths != null) {
       Calendar future = Calendar.getInstance();
       future.add(Calendar.MONTH, autoCancelMonths);


### PR DESCRIPTION
DO NOT MERGE! Yet. This was an important fix within the Donation Spring code that I'm cherry-picking here. But this needs tested with client donation forms, other than just Donation Spring.